### PR TITLE
Rename rest package to server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ run:
 
 test:
 	go vet ./...
-	ginkgo -p -r -race -cover -keepGoing -nodes=4 .
+	ginkgo -r -cover -keepGoing .
 
 test_coverage:
 	@go get github.com/modocache/gover
 	@go get github.com/mattn/goveralls
-	@ginkgo -cover -coverpkg=./... tests
+	@ginkgo -cover -coverpkg=./... -r
 	@gover
 	@mv gover.coverprofile coverage.txt

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/flavioribeiro/gonfig"
-	"github.com/snickers/snickers/rest"
+	"github.com/snickers/snickers/server"
 )
 
 func main() {
@@ -15,5 +15,5 @@ func main() {
 	cfg, _ := gonfig.FromJsonFile(currentDir + "/config.json")
 	port, _ := cfg.GetString("PORT", "8080")
 	fmt.Println("Starting Snickers on port", port)
-	log.Fatal(http.ListenAndServe(":"+port, rest.NewRouter()))
+	log.Fatal(http.ListenAndServe(":"+port, server.NewRouter()))
 }

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -1,4 +1,4 @@
-package rest
+package server
 
 import (
 	"fmt"

--- a/server/job_handlers.go
+++ b/server/job_handlers.go
@@ -1,4 +1,4 @@
-package rest
+package server
 
 import (
 	"encoding/json"

--- a/server/preset_handlers.go
+++ b/server/preset_handlers.go
@@ -1,4 +1,4 @@
-package rest
+package server
 
 import (
 	"encoding/json"

--- a/server/routes.go
+++ b/server/routes.go
@@ -1,4 +1,4 @@
-package rest
+package server
 
 import (
 	"net/http"

--- a/tests/rest_helpers_test.go
+++ b/tests/rest_helpers_test.go
@@ -7,14 +7,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/snickers/snickers/rest"
+	"github.com/snickers/snickers/server"
 )
 
-var _ = Describe("Rest API", func() {
+var _ = Describe("Server API", func() {
 	Context("helper functions", func() {
 		It("should write the error as json", func() {
 			w := httptest.NewRecorder()
-			rest.HTTPError(w, http.StatusOK, "error here", errors.New("database broken"))
+			server.HTTPError(w, http.StatusOK, "error here", errors.New("database broken"))
 
 			Expect(w.Code).To(Equal(http.StatusOK))
 			Expect(w.Body.String()).To(Equal(`{"error": "error here: database broken"}`))

--- a/tests/rest_job_test.go
+++ b/tests/rest_job_test.go
@@ -11,20 +11,20 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/snickers/snickers/db"
-	"github.com/snickers/snickers/rest"
+	"github.com/snickers/snickers/server"
 	"github.com/snickers/snickers/types"
 )
 
-var _ = Describe("Rest API", func() {
+var _ = Describe("Server API", func() {
 	var (
 		response   *httptest.ResponseRecorder
-		server     *mux.Router
+		s          *mux.Router
 		dbInstance db.DatabaseInterface
 	)
 
 	BeforeEach(func() {
 		response = httptest.NewRecorder()
-		server = rest.NewRouter()
+		s = server.NewRouter()
 		dbInstance, _ = db.GetDatabase()
 		dbInstance.ClearDatabase()
 	})
@@ -32,7 +32,7 @@ var _ = Describe("Rest API", func() {
 	Describe("GET /jobs", func() {
 		It("should return application/json on its content type", func() {
 			request, _ := http.NewRequest("GET", "/jobs", nil)
-			server.ServeHTTP(response, request)
+			s.ServeHTTP(response, request)
 			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
 		})
 
@@ -46,7 +46,7 @@ var _ = Describe("Rest API", func() {
 			expected2, _ := json.Marshal(`[{"id":"321","source":"","destination":"","preset":{"video":{},"audio":{}},"status":"","progress":""},{"id":"123","source":"","destination":"","preset":{"video":{},"audio":{}},"status":"","progress":""}]`)
 
 			request, _ := http.NewRequest("GET", "/jobs", nil)
-			server.ServeHTTP(response, request)
+			s.ServeHTTP(response, request)
 			responseBody, _ := json.Marshal(response.Body.String())
 
 			Expect(response.Code).To(Equal(http.StatusOK))
@@ -59,7 +59,7 @@ var _ = Describe("Rest API", func() {
 			dbInstance.StorePreset(types.Preset{Name: "presetName"})
 			jobJSON := []byte(`{"source": "http://flv.io/src.mp4", "destination": "s3://l@p:google.com", "preset": "presetName"}`)
 			request, _ := http.NewRequest("POST", "/jobs", bytes.NewBuffer(jobJSON))
-			server.ServeHTTP(response, request)
+			s.ServeHTTP(response, request)
 			responseBody := response.Body.String()
 
 			jobs, _ := dbInstance.GetJobs()
@@ -80,7 +80,7 @@ var _ = Describe("Rest API", func() {
 			It("should return BadRequest if preset is not set", func() {
 				jobJSON := []byte(`{"source": "http://flv.io/src.mp4", "destination": "s3://l@p:google.com", "preset": "presetName"}`)
 				request, _ := http.NewRequest("POST", "/jobs", bytes.NewBuffer(jobJSON))
-				server.ServeHTTP(response, request)
+				s.ServeHTTP(response, request)
 				responseBody, _ := json.Marshal(response.Body.String())
 
 				expected, _ := json.Marshal(`{"error": "retrieving preset: preset not found"}`)
@@ -92,7 +92,7 @@ var _ = Describe("Rest API", func() {
 			It("should return BadRequest if preset is malformed", func() {
 				jobJSON := []byte(`{"source: "http://flv.io/src.mp4", "destinat}`)
 				request, _ := http.NewRequest("POST", "/jobs", bytes.NewBuffer(jobJSON))
-				server.ServeHTTP(response, request)
+				s.ServeHTTP(response, request)
 				responseBody, _ := json.Marshal(response.Body.String())
 
 				expected, _ := json.Marshal(`{"error": "unpacking job: invalid character 'h' after object key"}`)
@@ -117,7 +117,7 @@ var _ = Describe("Rest API", func() {
 			expected, _ := json.Marshal(&job)
 
 			request, _ := http.NewRequest("GET", "/jobs/123-123-123", nil)
-			server.ServeHTTP(response, request)
+			s.ServeHTTP(response, request)
 			Expect(response.Body.String()).To(Equal(string(expected)))
 			Expect(response.Code).To(Equal(http.StatusOK))
 			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
@@ -126,7 +126,7 @@ var _ = Describe("Rest API", func() {
 		Context("when getting the job fails", func() {
 			It("should return BadRequest", func() {
 				request, _ := http.NewRequest("GET", "/jobs/123-456-9292", nil)
-				server.ServeHTTP(response, request)
+				s.ServeHTTP(response, request)
 				expected, _ := json.Marshal(`{"error": "retrieving job: job not found"}`)
 				responseBody, _ := json.Marshal(response.Body.String())
 				Expect(responseBody).To(Equal(expected))
@@ -149,7 +149,7 @@ var _ = Describe("Rest API", func() {
 			dbInstance.StoreJob(job)
 
 			request, _ := http.NewRequest("POST", "/jobs/123-123-123/start", nil)
-			server.ServeHTTP(response, request)
+			s.ServeHTTP(response, request)
 			Expect(response.Code).To(Equal(http.StatusOK))
 			Expect(response.HeaderMap["Content-Type"][0]).To(Equal("application/json; charset=UTF-8"))
 		})
@@ -157,7 +157,7 @@ var _ = Describe("Rest API", func() {
 		Context("when starting a job fails", func() {
 			It("should return BadRequest", func() {
 				request, _ := http.NewRequest("POST", "/jobs/123-456-9292/start", nil)
-				server.ServeHTTP(response, request)
+				s.ServeHTTP(response, request)
 				expected, _ := json.Marshal(`{"error": "retrieving job: job not found"}`)
 				responseBody, _ := json.Marshal(response.Body.String())
 				Expect(responseBody).To(Equal(expected))


### PR DESCRIPTION
Another PR will introduce `SnickersServer`, e.g:

```go
type SnickersServer struct {
	listenAddr    string
	listenNetwork string

	logger lager.Logger
	net.Listener
	router        *Router
	server        *http.Server
}
```