### PR TITLE
Add unit test and remove unused code

### DIFF
--- a/server/router.go
+++ b/server/router.go
@@ -15,10 +15,9 @@ type Router struct {
 }
 
 type RouterArguments struct {
-	Handler    http.HandlerFunc
-	Path       string
-	PathPrefix string
-	Method     string
+	Handler http.HandlerFunc
+	Path    string
+	Method  string
 }
 
 func NewRouter() *Router {
@@ -33,18 +32,6 @@ func (router *Router) Handler() http.Handler {
 }
 
 func (router *Router) AddHandler(args RouterArguments) {
-	var r *mux.Router
-
-	if sub, ok := router.sub[args.PathPrefix]; ok {
-		r = sub
-	} else {
-		r = router.r
-	}
-
-	var prefix, path string
-	if args.PathPrefix != "" {
-		prefix = fmt.Sprintf("/%s", strings.Trim(args.PathPrefix, "/"))
-	}
-	path = fmt.Sprintf("/%s", strings.Trim(args.Path, "/"))
-	r.Methods(args.Method).Path(fmt.Sprintf("%s%s", prefix, path)).HandlerFunc(JSONHandler(args.Handler))
+	path := fmt.Sprintf("/%s", strings.Trim(args.Path, "/"))
+	router.r.Methods(args.Method).Path(fmt.Sprintf("%s", path)).HandlerFunc(JSONHandler(args.Handler))
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -66,11 +66,21 @@ var _ = Describe("Snickers Server", func() {
 			})
 
 			It("removes the existing socket", func() {
-				Expect(snickersServer.Stop()).NotTo(HaveOccurred())
+				Expect(snickersServer.Stop()).To(Succeed())
 
 				info, err := os.Stat(socketPath)
 				Expect(err).To(HaveOccurred())
 				Expect(info).To(BeNil())
+			})
+
+			Context("when fails to stop the server because it's already stopped", func() {
+				JustBeforeEach(func() {
+					Expect(snickersServer.Stop()).NotTo(HaveOccurred())
+				})
+
+				It("returns an error", func() {
+					Expect(snickersServer.Stop()).To(HaveOccurred())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
* Simplify router logic by removing unused prefix
* Return an error when fails to stop the server