### PR TITLE
HTTPError helper now uses http.Error from net/http

### DIFF
--- a/server/helpers.go
+++ b/server/helpers.go
@@ -7,7 +7,7 @@ import (
 
 // HTTPError is a helper to return errors on handlers
 func HTTPError(w http.ResponseWriter, httpErr int, msg string, err error) {
-	msg := fmt.Sprintf(`{"error": "%s: %s"}`, msg, err.Error())
+	msg = fmt.Sprintf(`{"error": "%s: %s"}`, msg, err.Error())
 	http.Error(w, msg, httpErr)
 	return
 }

--- a/server/helpers.go
+++ b/server/helpers.go
@@ -7,8 +7,9 @@ import (
 
 // HTTPError is a helper to return errors on handlers
 func HTTPError(w http.ResponseWriter, httpErr int, msg string, err error) {
-	w.WriteHeader(httpErr)
-	fmt.Fprintf(w, `{"error": "%s: %s"}`, msg, err.Error())
+	msg := fmt.Sprintf(`{"error": "%s: %s"}`, msg, err.Error())
+	http.Error(w, msg, httpErr)
+	return
 }
 
 // JSONHandler adds json headers


### PR DESCRIPTION
Fixes #28 