### PR TITLE
Missing returned error

### DIFF
--- a/encoders/ffmpeg.go
+++ b/encoders/ffmpeg.go
@@ -54,7 +54,7 @@ func FFMPEGEncode(logger lager.Logger, dbInstance db.Storage, jobID string) erro
 		return err
 	}
 
-	processNewFrames(inputCtx, outputCtx, streamMap)
+	err = processNewFrames(inputCtx, outputCtx, streamMap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Seems like the error for `processNewFrames` is not processed correctly. It doesn't seem done purposefuly.

This commit corrects it.

Cheers